### PR TITLE
provide a raw through function with --through arg

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,6 +9,6 @@ var transform = args._[0]
 if (args.file) transform = require(path.resolve(process.cwd(), args.file))
 
 process.stdin
-  .pipe(map(transform))
+  .pipe(map(transform, args))
   .pipe(ldj.serialize())
   .pipe(process.stdout)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jsonmap",
   "description": "streaming command line newline-delimited json transformer utility",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "bin": {
     "jsonmap": "cli.js"
   },

--- a/readme.md
+++ b/readme.md
@@ -47,3 +47,26 @@ module.exports = function() {
   this.pizza = 1
 }
 ```
+
+if you want to provide a [through2](https://github.com/rvagg/through2) function in a file for more control, or async, you can
+
+```BASH
+$ echo '{"foo": "bar"}\n{"baz": "taco"}' | jsonmap --file=transform.js --through
+{"foo":"bar","pizza":1}
+{"baz":"taco","pizza":1}
+```
+
+the above will work if `transform.js` has the following contents:
+
+```js
+module.exports = function(obj, enc, next) {
+  var self = this;
+  if(obj.foo === 'bar') return next() // skip the bar
+  process.nextTick(function(){
+    self.push({ count: obj.pizza })
+    next()
+  })
+}
+```
+
+

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,10 @@ exec('cat test.json | node ../cli.js --file=test-transform.js',
 exec('cat test.json | node ../cli.js \"{dog: this.dog}\" | node ../cli.js --file=test-transform2.js',
   expect('{"dog":6}\n{"dog":7}\n'));
 
+exec('cat test.json | node ../cli.js \"{dog: this.dog}\" | node ../cli.js --file=test-transform3.js --through',
+  expect('{"dog":5}\n{"dog":6}\n{"dog":7}\n'));
+
+
 function expect(output) {
   function done(err, stdout, stderr) {
     if(stdout !== output) {
@@ -19,6 +23,6 @@ function expect(output) {
     console.log(stdout);
     if(err) { throw err; }
   }
-  
+
   return done;
 }

--- a/test/test-transform3.js
+++ b/test/test-transform3.js
@@ -1,0 +1,12 @@
+module.exports = function(data, enc, next){
+  var self = this;
+  if (data.dog == 5) {
+    self.push(data)
+  }
+
+  process.nextTick(function(){
+    data.dog++
+    self.push(data)
+    next()
+  })
+}


### PR DESCRIPTION
I needed a way to do some async work in the provided file. This exposes the exported function as a through2 function when the --through flag is passed to the cmd line.

I have updated the readme, and provided a test case.

I have bumped the minor version number. If merged, could you also publish to npm?
