### PR TITLE
Add es6 template strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function createFunctionStream(func) {
   if(typeof func !== 'function') {
     var funcStr = func + ';\n return this;'
     if (func[0] === '{') funcStr = 'var that = ' + func + ';\n return that;'
+    if(func[0] === '`') funcStr = 'var that = ' + func + ';\n return that;'
     compiled = new Function(funcStr)
   }
   else {

--- a/index.js
+++ b/index.js
@@ -13,8 +13,7 @@ function createFunctionStream(func) {
   var compiled;
   if(typeof func !== 'function') {
     var funcStr = func + ';\n return this;'
-    if (func[0] === '{') funcStr = 'var that = ' + func + ';\n return that;'
-    if(func[0] === '`') funcStr = 'var that = ' + func + ';\n return that;'
+    if (func[0] === '{' || func[0] === '`') funcStr = 'var t = ' + func + ';\n return t;'
     compiled = new Function(funcStr)
   }
   else {

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ module.exports = function() {
 }
 ```
 
-if you have es6 enabled on your platform, template strings will work as well
+if you have es6 template strings enabled on your platform (e.g. iojs), template strings will work as well
 
 ```BASH
 $ echo '{"meal": "pizza"}\n{"meal": "taco"}' | jsonmap '`i love ${this.meal}`'

--- a/readme.md
+++ b/readme.md
@@ -47,3 +47,11 @@ module.exports = function() {
   this.pizza = 1
 }
 ```
+
+if you have es6 enabled on your platform, template strings will work as well
+
+```BASH
+$ echo '{"meal": "pizza"}\n{"meal": "taco"}' | jsonmap '`i love ${this.meal}`'
+"i love pizza"
+"i love taco"
+```

--- a/test/index.js
+++ b/test/index.js
@@ -11,8 +11,10 @@ exec('cat test.json | node ../cli.js --file=test-transform.js',
 exec('cat test.json | node ../cli.js \"{dog: this.dog}\" | node ../cli.js --file=test-transform2.js',
   expect('{"dog":6}\n{"dog":7}\n'));
 
-exec('cat test.json | node ../cli.js \'\`${this.dog} dogs\`\'',
-  expect('"5 dogs"\n"6 dogs"\n'));
+supportsTemplateStrings(function () {
+  exec('cat test.json | node ../cli.js \'\`${this.dog} dogs\`\'',
+    expect('"5 dogs"\n"6 dogs"\n'));
+})
 
 function expect(output) {
   function done(err, stdout, stderr) {
@@ -24,4 +26,11 @@ function expect(output) {
   }
   
   return done;
+}
+
+function supportsTemplateStrings(cb) {
+  try {
+    eval('``');
+    cb();
+  } catch(e) {}
 }

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,9 @@ exec('cat test.json | node ../cli.js --file=test-transform.js',
 exec('cat test.json | node ../cli.js \"{dog: this.dog}\" | node ../cli.js --file=test-transform2.js',
   expect('{"dog":6}\n{"dog":7}\n'));
 
+exec('cat test.json | node ../cli.js \'\`${this.dog} dogs\`\'',
+  expect('"5 dogs"\n"6 dogs"\n'));
+
 function expect(output) {
   function done(err, stdout, stderr) {
     if(stdout !== output) {


### PR DESCRIPTION
Allows cool transformations:

```BASH
$ echo '{"meal": "pizza"}\n{"meal": "taco"}' | jsonmap '`i love ${this.meal}`'
"i love pizza"
"i love taco"
```